### PR TITLE
Memoize the SQL file

### DIFF
--- a/src/oksql/core.clj
+++ b/src/oksql/core.clj
@@ -53,11 +53,13 @@
         (throw (Exception. (str "Parameter mismatch. Expected " (string/join ", " (map kebab sql-ks)) ". Got " (string/join ", " (map kebab (keys m))))))))))
 
 (defn get-lines [s]
-  (let [s (string/replace s "-" "_")
-        resource (io/resource (str "sql/" s))]
-    (if (nil? resource)
-      (throw (Exception. (str s " doesn't exist!")))
-      (slurp resource))))
+  (memoize
+   (fn [s]
+     (let [s (string/replace s "-" "_")
+           resource (io/resource (str "sql/" s))]
+       (if (nil? resource)
+         (throw (Exception. (str s " doesn't exist!")))
+         (slurp resource))))))
 
 (defn db-query
   ([db sql-vec]


### PR DESCRIPTION
As per issue #1, memoizing the file.

**tl;dr**: memoized is 26 µs, non memoized is around 48 µs.

<hl/>

These are some of the stats:

Measuring the usage of **get-lines**.

First is the function without memoization, both criterium's
`quick-bench` and `bench` (because bench is a bit slower but
thorough). Then the results of the memoized function.


## Original

* Quick-bench
```
oksql.core> (criterium/quick-bench (get-lines "items.sql"))
Evaluation count : 12888 in 6 samples of 2148 calls.
             Execution time mean : 48.660463 µs
    Execution time std-deviation : 2.406675 µs
   Execution time lower quantile : 46.279284 µs ( 2.5%)
   Execution time upper quantile : 51.775439 µs (97.5%)
                   Overhead used : 1.699019 ns
```
* Bench
```
oksql.core> (criterium/bench (get-lines "items.sql"))
Evaluation count : 1248000 in 60 samples of 20800 calls.
             Execution time mean : 51.508409 µs
    Execution time std-deviation : 2.909023 µs
   Execution time lower quantile : 47.904481 µs ( 2.5%)
   Execution time upper quantile : 58.658848 µs (97.5%)
                   Overhead used : 1.699019 ns

Found 5 outliers in 60 samples (8.3333 %)
	low-severe	 3 (5.0000 %)
	low-mild	 2 (3.3333 %)
 Variance from outliers : 41.8002 % Variance is moderately inflated by outliers
```
## Memoized

* Quick-bench
```
oksql.core> (criterium/quick-bench (get-lines "items.sql"))
Evaluation count : 22041846 in 6 samples of 3673641 calls.
             Execution time mean : 26.431870 ns
    Execution time std-deviation : 1.935759 ns
   Execution time lower quantile : 24.042641 ns ( 2.5%)
   Execution time upper quantile : 28.892372 ns (97.5%)
                   Overhead used : 1.699019 ns

Found 2 outliers in 6 samples (33.3333 %)
	low-severe	 1 (16.6667 %)
	low-mild	 1 (16.6667 %)
 Variance from outliers : 15.3180 % Variance is moderately inflated by outliers
```
* Bench
```
oksql.core> (criterium/bench (get-lines "items.sql"))
Evaluation count : 2103924120 in 60 samples of 35065402 calls.
             Execution time mean : 26.829950 ns
    Execution time std-deviation : 0.466195 ns
   Execution time lower quantile : 26.067198 ns ( 2.5%)
   Execution time upper quantile : 27.745514 ns (97.5%)
                   Overhead used : 1.699019 ns

Found 2 outliers in 60 samples (3.3333 %)
	low-severe	 1 (1.6667 %)
	low-mild	 1 (1.6667 %)
 Variance from outliers : 6.2833 % Variance is slightly inflated by outliers
```